### PR TITLE
Feature/mmr larlite opreco updates

### DIFF
--- a/ubcv/LArCVImageMaker/ImageMetaFromConfig.cxx
+++ b/ubcv/LArCVImageMaker/ImageMetaFromConfig.cxx
@@ -12,7 +12,7 @@ namespace supera {
     auto min_wire = cfg.get<double>("MinWire");
     auto image_rows = cfg.get<std::vector<size_t> >("EventImageRows");
     auto image_cols = cfg.get<std::vector<size_t> >("EventImageCols");
-    bool tick_backward = cfg.get<bool>("TickBackward",true);
+    bool tick_backward = cfg.get<bool>("TickBackward",false); // from DLGen1 - deprecated
 
     auto const& comp_rows = RowCompressionFactor();
     auto const& comp_cols = ColCompressionFactor();

--- a/ubcv/LArCVImageMaker/LAr2Image.cxx
+++ b/ubcv/LArCVImageMaker/LAr2Image.cxx
@@ -92,12 +92,12 @@ namespace supera {
 	int start_index = range.begin_index() + time_offset;
 	int end_index   = start_index + adcs.size() - 1;
 	if (start_index > ymax) {
-	  LARCV_SINFO() << "Wire[" << wire.Channel() << "] ROI[" << nrois-1 << "] start index (" << start_index << ") is past the image end bound (" << ymax << ")" << std::endl;
+	  LARCV_SDEBUG() << "Wire[" << wire.Channel() << "] ROI[" << nrois-1 << "] start index (" << start_index << ") is past the image end bound (" << ymax << ")" << std::endl;
 	  nroi_outofbounds++;
 	  continue;
 	}
 	else if ( end_index < ymin) {
-	  LARCV_SINFO() << "Wire[" << wire.Channel() << "] ROI[" << nrois-1 << "] start index (" << end_index << ") is before the image starting bound (" << ymin << ")" << std::endl;
+	  LARCV_SDEBUG() << "Wire[" << wire.Channel() << "] ROI[" << nrois-1 << "] start index (" << end_index << ") is before the image starting bound (" << ymin << ")" << std::endl;
 	  nroi_outofbounds++;
 	  continue;
 	}

--- a/ubcv/LArCVImageMaker/LArCVWCThrumuImage.cxx
+++ b/ubcv/LArCVImageMaker/LArCVWCThrumuImage.cxx
@@ -1,0 +1,198 @@
+#include "LArCVWCThrumuImage.h"
+
+#include "larcv/core/Base/larcv_logger.h"
+
+namespace supera {
+
+  std::vector<larcv::Image2D> 
+  WCThrumuTaggerHits2Image2D( const std::vector<supera::LArHit_t>& thrumu_hits,
+			      const std::vector<larcv::Image2D>& adc_v )
+  {
+    
+    // make output image2d container
+    std::vector< larcv::Image2D > outoftime_v; // pixels show us what have been tagged as out-of-time
+    //std::vector< larcv::Image2D > intime_v;    // pixels show us what has been tagged as in-time
+    
+    for (size_t p=0; p<adc_v.size(); p++) {
+      larcv::Image2D out_img( adc_v.at(p) );        // copy
+      //larcv::Image2D in_img( adc_v.at(p).meta() );  // making blank
+      outoftime_v.emplace_back( std::move(out_img) );
+      //intime_v.emplace_back( std::move(in_img) );
+    }
+    
+    int nhits_removed_pixels = 0;
+    for (size_t idx=0; idx < thrumu_hits.size(); idx++) {
+      auto const& hit = thrumu_hits.at(idx);
+      int plane = hit.View();
+    
+      if ( plane<0 || plane>=(int)outoftime_v.size() )
+	continue;
+      
+      auto& outoftime = outoftime_v.at(plane);
+      
+      int nremoved = remove_from_hit( outoftime, hit, 2 );
+      if ( nremoved>0 )
+	nhits_removed_pixels++;
+      
+    }
+    
+    LARCV_SINFO() << "Number of the total (" << thrumu_hits.size() << ") "
+		  << "hits that removed pixels is " << nhits_removed_pixels 
+		  << std::endl;
+    
+    return outoftime_v;
+    
+  }
+
+  int remove_from_hit(larcv::Image2D& removed_img, 
+		      const supera::LArHit_t& hit,
+		      int padding){
+    /*
+      this function takes in an image and a hit, and removes charge in the Image
+      based on the hit's position, with some padding around it (default padding of 2)
+    */
+
+    //int row = 0;
+    //int plane = 0;
+    int col = 0;
+    int minrow = 0;
+    int maxrow = 0;
+    float offset = -3;
+    const larcv::ImageMeta& meta = removed_img.meta();
+
+    float maxtick = hit.PeakTime()+2400+hit.SigmaPeakTime();
+    float mintick = hit.PeakTime()+2400-hit.SigmaPeakTime();
+    //std::cout << "mintick1: " << mintick << " " << maxtick << std::endl;
+    if ( maxtick >= meta.max_y() )
+      maxtick = meta.max_y()-meta.pixel_height();
+    if ( mintick <= meta.min_y() )
+      mintick = meta.min_y()+meta.pixel_height();
+    //std::cout << "mintick2: " << mintick << " " << maxtick << std::endl;
+
+    if (mintick>=meta.max_y()) {
+      return 0; // not removing
+    }
+    if (maxtick<=meta.min_y()) {
+      return 0; // not removing
+    }
+    
+    float peaktick = hit.PeakTime()+2400+offset;
+    if ( peaktick>=meta.max_y() ) 
+      return 0;
+    if ( peaktick<=meta.min_y() ) 
+      return 0;
+
+    int channel = (int)hit.Channel();
+    if ( hit.View()==2 )
+      channel -= 2*2400;
+    else if ( hit.View()==1 )
+      channel -= 2400;
+
+    minrow = meta.row(mintick,__FILE__,__LINE__);
+    maxrow = meta.row(maxtick,__FILE__,__LINE__);
+    col = meta.col(channel);
+  
+    if ( minrow>maxrow ) {
+      int tmp = minrow;
+      minrow = maxrow;
+      maxrow = tmp;
+    }
+    
+    int pixels_zeroed = 0;
+    for (int r = minrow-padding; r <= maxrow+padding; r++){
+      if (r<0 ) continue;
+      if (r>=(int)removed_img.meta().rows()) continue;
+      for(int c = col-padding; c <= col+padding; c++){
+	if (c<0 ) continue;
+	if (c>=(int)removed_img.meta().cols()) continue;
+	
+	if ( removed_img.pixel(r,c)>10.0 )
+	  pixels_zeroed++;
+	removed_img.set_pixel(r,c,0);
+      }
+    }
+    
+    return pixels_zeroed;
+    
+  }
+
+//   void overlay_from_hit(larcv::Image2D& new_img, const larcv::Image2D& old_img, const larlite::hit& hit, int padding){
+//     /*
+//       this image takes in a new image, and an old image, and overlays the old img
+//       on top of the new img where the hit is located in row and col with some padding
+//       around the hit location
+//       if the column is all 0s in the padded region then instead you overlay a
+//       value of 50 at the hit location
+//   */
+//   int row;
+//   int col;
+//   int plane;
+//   float showerscore;
+//   float hit_dist;
+//   int minrow;
+//   int maxrow;
+//   float offset = -3;
+//   larcv::ImageMeta meta = old_img.meta();
+
+//   float maxtick = hit.PeakTime()+2400+hit.SigmaPeakTime();
+//   float mintick = hit.PeakTime()+2400-hit.SigmaPeakTime();
+//   if ( maxtick >= meta.max_y() )
+//     maxtick = meta.max_y()-meta.pixel_height();
+//   if ( mintick <= meta.min_y() )
+//     mintick = meta.min_y()+meta.pixel_height();
+
+//   if (mintick>=meta.max_y()) return;
+//   if (maxtick<=meta.min_y()) return;
+
+//   float peaktick = hit.PeakTime()+2400+offset;
+//   if ( peaktick>=meta.max_y() ) return;
+//   if ( peaktick<=meta.min_y() ) return;  
+  
+//   if(hit.View()==2){
+//     plane = 2;
+//     minrow = meta.row(mintick,__FILE__,__LINE__);
+//     maxrow = meta.row(maxtick,__FILE__,__LINE__);
+//     row = meta.row(hit.PeakTime()+2400+offset,__FILE__,__LINE__);
+//     col = meta.col(hit.Channel()-2*2400,__FILE__,__LINE__);
+//   }
+//   else if (hit.View()==0){
+//     minrow = meta.row(mintick,__FILE__,__LINE__);
+//     maxrow = meta.row(maxtick,__FILE__,__LINE__);
+//     row = meta.row(hit.PeakTime()+2400+offset,__FILE__,__LINE__);
+//     col = meta.col(hit.Channel(),__FILE__,__LINE__);
+//     plane = 0;
+//   }
+//   else if (hit.View()==1){
+//     minrow = meta.row(mintick,__FILE__,__LINE__);
+//     maxrow = meta.row(maxtick,__FILE__,__LINE__);
+//     row = meta.row(hit.PeakTime()+2400+offset,__FILE__,__LINE__);
+//     col = meta.col(hit.Channel()-2400,__FILE__,__LINE__);
+//     plane = 1;
+//   }
+
+//   if ( minrow>maxrow ) {
+//     int tmp = minrow;
+//     minrow = maxrow;
+//     maxrow = tmp;
+//   }
+  
+//   for(int c = col-padding; c <= col+padding; c++){
+//     double col_sum = 0;
+//     if ( c<0 ) continue;
+//     if ( c>=(int)new_img.meta().cols() ) continue;
+//     for (int r = minrow-padding; r <= maxrow+padding; r++){
+//       if ( r<0) continue;
+//       if ( r>=new_img.meta().rows() ) continue;
+//       double val = old_img.pixel(r,c);
+//       col_sum += val;
+//       new_img.set_pixel(r,c,val);
+//     }
+//     if (col_sum == 0) {
+//       // std::cout << "FLAG Hit Placed in Dead Region\n";
+//       new_img.set_pixel(row,c,50.000);
+//     }
+//   }
+//   return;
+// }
+
+}

--- a/ubcv/LArCVImageMaker/LArCVWCThrumuImage.h
+++ b/ubcv/LArCVImageMaker/LArCVWCThrumuImage.h
@@ -1,0 +1,21 @@
+#ifndef __UBCV_LARCVIMAGEMAKER_LARCV_WC_THRUMU_IMAGEMAKER_H__
+#define __UBCV_LARCVIMAGEMAKER_LARCV_WC_THRUMU_IMAGEMAKER_H__
+
+#include <vector>
+
+#include "FMWKInterface.h"
+#include "larcv/core/DataFormat/Image2D.h"
+
+namespace supera {
+
+  std::vector<larcv::Image2D> 
+    WCThrumuTaggerHits2Image2D( const std::vector<supera::LArHit_t>& thrumu_hits, // type declared in FMWKInterface.h
+				const std::vector<larcv::Image2D>& adc_v );
+
+  int remove_from_hit(larcv::Image2D& removed_img, 
+		      const supera::LArHit_t& hit,
+		      int padding=2);
+  
+}
+
+#endif

--- a/ubcv/LArCVImageMaker/SuperaLArFlow.cxx
+++ b/ubcv/LArCVImageMaker/SuperaLArFlow.cxx
@@ -34,7 +34,7 @@ namespace larcv {
       throw std::runtime_error("SuperaLArFlow: must specifc only one SimCh or SimEdep producer");
     }
     _edep_at_anode     = cfg.get<bool>("EdepAtAnode",true);
-    _tick_backward     = cfg.get<bool>("TickBackward",true);
+    _tick_backward     = cfg.get<bool>("TickBackward",false); // for DLGen1 - deprecated
   }
 
   void SuperaLArFlow::initialize()

--- a/ubcv/LArCVImageMaker/SuperaSimCh.cxx
+++ b/ubcv/LArCVImageMaker/SuperaSimCh.cxx
@@ -21,7 +21,7 @@ namespace larcv {
     supera::ParamsImage2D::configure(cfg);
     supera::ImageMetaMaker::configure(cfg);
     _origin = cfg.get<unsigned short>("Origin",0);
-    _tick_backward = cfg.get<bool>("TickBackward",true);
+    _tick_backward = cfg.get<bool>("TickBackward",false); // from DLGen1 - deprecated
   }
 
   void SuperaSimCh::initialize()

--- a/ubcv/LArCVImageMaker/SuperaWCThrumuImage.cxx
+++ b/ubcv/LArCVImageMaker/SuperaWCThrumuImage.cxx
@@ -1,0 +1,75 @@
+#ifndef __UBCV_LARCVIMAGEMAKER_SUPERA_WC_THRUMU_IMAGE_CXX__
+#define __UBCV_LARCVIMAGEMAKER_SUPERA_WC_THRUMU_IMAGE_CXX__
+
+#include "SuperaWCThrumuImage.h"
+#include "LArCVWCThrumuImage.h"
+#include "ImageMetaMakerFactory.h"
+#include "larcv/core/DataFormat/EventImage2D.h"
+
+namespace larcv {
+
+  static SuperaWCThrumuImageProcessFactory __global_SuperaWCThrumuImageProcessFactory__;
+
+  SuperaWCThrumuImage::SuperaWCThrumuImage(const std::string name)
+    : SuperaBase(name)
+  {}
+
+  void SuperaWCThrumuImage::configure(const PSet& cfg)
+  {
+    
+    SuperaBase::configure(cfg); 
+    // Inherited in SuperBase is the parameter 'LArHitProducer' which needs to be set to get input Hits
+    // Determines what product holding recob::Hit container is used when LArData<supera::LArHit_t>() is called
+
+    supera::ImageMetaMaker::configure(cfg);
+
+    _input_wireimage_treename     = cfg.get<std::string>("InputWireTreeName");
+    _output_image2d_treename = cfg.get<std::string>("OutImageLabel","thrumu");
+
+  }
+
+  void SuperaWCThrumuImage::initialize()
+  { SuperaBase::initialize(); }
+
+  bool SuperaWCThrumuImage::process(IOManager& mgr)
+  {
+
+    SuperaBase::process(mgr);
+
+    auto const& meta_v = Meta();
+    
+    if(meta_v.empty()) {
+      LARCV_CRITICAL() << "Meta not created!" << std::endl;
+      throw larbys();
+    }
+    auto ev_image = (EventImage2D*)(mgr.get_data(kProductImage2D,_output_image2d_treename));
+    if(!ev_image) {
+      LARCV_CRITICAL() << "Output image could not be created!" << std::endl;
+      throw larbys();
+    }
+    if(!(ev_image->Image2DArray().empty())) {
+      LARCV_CRITICAL() << "Output image array not empty!" << std::endl;
+      throw larbys();
+    }
+    
+    larcv::EventImage2D* ev_wire = 
+      (larcv::EventImage2D*)mgr.get_data(kProductImage2D,_input_wireimage_treename);
+
+    if ( ev_wire->as_vector().size()==0 ) {
+      LARCV_CRITICAL() << "Input Wire Images not made yet!" << std::endl;
+    }
+
+    std::vector<larcv::Image2D> out_thrumu_v = 
+      supera::WCThrumuTaggerHits2Image2D( LArData<supera::LArHit_t>(), ev_wire->as_vector() );
+
+    ev_image->Emplace(std::move(out_thrumu_v));
+
+    return true;
+  }
+
+  void SuperaWCThrumuImage::finalize()
+  {}
+
+
+}
+#endif

--- a/ubcv/LArCVImageMaker/SuperaWCThrumuImage.h
+++ b/ubcv/LArCVImageMaker/SuperaWCThrumuImage.h
@@ -1,0 +1,74 @@
+/**
+ * \file SuperaWCThrumuImage.h
+ *
+ * \ingroup LArCVImageMaker
+ * 
+ * \brief Class def header for a class SuperaWCThrumuImage
+ *
+ * @author Taritree
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __UBCV_LARCVIMAGEMAKER_SUPERA_WC_THRUMU_IMAGE_H__
+#define __UBCV_LARCVIMAGEMAKER_SUPERA_WC_THRUMU_IMAGE_H__
+
+#include "SuperaBase.h"
+#include "FMWKInterface.h"
+#include "ParamsImage2D.h"
+#include "ImageMetaMaker.h"
+
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class SuperaWire ... these comments are used to generate
+     doxygen documentation!
+  */
+  class SuperaWCThrumuImage : public SuperaBase,
+    public supera::ImageMetaMaker {
+
+  public:
+    
+    /// Default constructor
+    SuperaWCThrumuImage(const std::string name="SuperaWCThrumuImage");
+    
+    /// Default destructor
+    ~SuperaWCThrumuImage(){}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+  protected:
+
+    std::string _output_image2d_treename;
+    std::string _input_wireimage_treename;
+    
+  };
+
+  /**
+     \class larcv::SuperaWCThrumuImageFactory
+     \brief A concrete factory class for larcv::SuperaWCThrumuImage
+  */
+  class SuperaWCThrumuImageProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    SuperaWCThrumuImageProcessFactory() { ProcessFactory::get().add_factory("SuperaWCThrumuImage",this); }
+    /// dtor
+    ~SuperaWCThrumuImageProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new SuperaWCThrumuImage(instance_name); }
+  };
+
+}
+#endif
+//#endif
+//#endif
+/** @} */ // end of doxygen group 
+

--- a/ubcv/LArCVImageMaker/SuperaWire.cxx
+++ b/ubcv/LArCVImageMaker/SuperaWire.cxx
@@ -20,7 +20,7 @@ namespace larcv {
     SuperaBase::configure(cfg);
     supera::ParamsImage2D::configure(cfg);
     supera::ImageMetaMaker::configure(cfg);
-    _tick_backward = cfg.get<bool>("TickBackward",true);
+    _tick_backward = cfg.get<bool>("TickBackward",false); // for DLGen1 - deprecated
   }
 
   void SuperaWire::initialize()

--- a/ubcv/LArCVImageMaker/example_drivers/supera_mctruth_w_wcthrumu.fcl
+++ b/ubcv/LArCVImageMaker/example_drivers/supera_mctruth_w_wcthrumu.fcl
@@ -1,0 +1,126 @@
+ProcessDriver: {
+
+  Verbosity:    1
+  EnableFilter: false
+  RandomAccess: false
+  ProcessType:  ["SuperaMetaMaker","SuperaSimCh","SuperaInstanceImage","SuperaMCROI","SuperaWire","SuperaChStatus","SuperaLArFlow","SuperaWCThrumuImage"]
+  ProcessName:  ["SuperaMetaMaker","SuperaSimCh","SuperaInstanceImage","SuperaMCROI","SuperaWire","SuperaChStatus","SuperaLArFlow","SuperaWCThrumuImage"]
+
+  IOManager: {
+    Verbosity: 2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaMetaMaker: {
+      Verbosity: 1
+      MetaConfig: {
+        MinTime:          2400
+        MinWire:          0
+        EventImageRows:   [1008,1008,1008]
+        EventImageCols:   [3456,3456,3456]
+        EventCompRows:    [6,6,6]
+        EventCompCols:    [1,1,1]
+      }
+    }
+    WireMask: {
+      Verbosity: 2
+      ChStatusProducer: "wiremc"
+      ImageProducer:    "wiremc"
+    }
+    SuperaSimCh: {
+      Verbosity: 2
+      OutImageLabel:       "segment"
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      Origin: 1
+      TimeOffset: 2400
+    }
+    SuperaInstanceImage: {
+      Verbosity: 0
+      OutImageLabel:        "instance"
+      AncestorImageLabel:   "ancestor"
+      OutROILabel:          "segment"
+      LArMCTruthProducer:   "generator"
+      LArMCTrackProducer:   "mcreco"
+      LArMCShowerProducer:  "mcreco"
+      LArSimChProducer:     "driftWC simpleSC"
+      ChStatusProducer:     "wiremc"
+      Origin: 0
+      TimeOffset: 2400
+    }
+    SuperaMCROI: {
+      Verbosity: 2
+      OutROILabel:         "segment"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      LArSimChProducer:    "driftWC simpleSC"
+      TimeOffset: 2400
+      Origin: 0
+      StoreG4SecondaryROI:  false
+      StoreG4PrimaryROI:    true
+      FilterTargetPDG:      []
+      FilterTargetInitEMin: []
+      FilterTargetDepEMin:  []
+      ShowerInitEMin: 0
+      ShowerDepEMin:  20
+      TrackInitEMin:  0
+      TrackDepEMin:   20
+      FilterROIMinRows: 0
+      FilterROIMinCols: 0
+      MCParticleTree: {
+        Verbosity:    2
+        UseG4Primary: false
+	DTMax:        10000
+      }
+      MCROIMaker: {
+        Verbosity:    2
+   	MaxTimeTick:  8448
+        TimePadding:  10
+        WirePadding:  10
+        MinWidth:     2
+        MinHeight:    2
+	ApplySCE:     true
+      }
+    }
+    SuperaWire: {
+      Verbosity: 2
+      OutImageLabel:    "wire"
+      LArWireProducer:  "butcher"
+      TimeOffset: 2400
+    }
+    SuperaChStatus: {
+      Verbosity: 2
+      LArChStatusProducer: "chstatus"
+      OutChStatusLabel:    "wire"
+    }
+    SuperaLArFlow: {
+      Verbosity: 0
+      OutImageLabel:       "larflow"
+      LArMCTruthProducer:  "generator"
+      LArMCTrackProducer:  "mcreco"
+      LArMCShowerProducer: "mcreco"
+      WireProducer:        "wiremc"
+      ChStatusProducer:    "wiremc"
+      LArSimChProducer:    "driftWC simpleSC"
+      EdepAtAnode: true
+    }
+    SuperaWCThrumuImage: {
+      Verbosity: 0
+      LArHitProducer: "portedThresholdhit"
+      InputWireTreeName: "wire"
+      OutImageLabel: "thrumu"
+    }
+  }
+}
+


### PR DESCRIPTION
sets default meta to tickforward as version of larcv (v1_0_1 on UPS) can only save a tick-forward meta.  also creates a new superamodule that zeros out pixels that are in-time, producing an image labeling pixels tagged as out-of-time. the info comes from hits made by the wire cell thrumu tagger.